### PR TITLE
Background position

### DIFF
--- a/scss/base.scss
+++ b/scss/base.scss
@@ -156,7 +156,7 @@ body {
       display: block;
       position: fixed;
       left: 0;
-      top: 0;
+      top: $nav-height;
       width: 100%;
       height: 100%;
       z-index: -10;

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -157,8 +157,8 @@ body {
       position: fixed;
       left: 0;
       top: $nav-height;
-      width: 100%;
-      height: 100%;
+      width: 100vw;
+      height: 100vh;
       z-index: -10;
       background: $primary-background-color $background-image no-repeat center center;
 

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -146,19 +146,27 @@ body {
       padding-right: 0.25 * $content-padding;
     }
 
+    // Thank you, stack overflow: https://stackoverflow.com/a/33057806
     &::before {
       $background-image: url('/img/NCAS_Logo_Website-Background.png');
       $background-opacity: 0.07;
-      $background-size: 90%;
+      $background-size: contain;
 
-      background: $primary-background-color $background-image no-repeat center fixed;
       content: '';
-      z-index: -1;
+      display: block;
+      position: fixed;
+      left: 0;
+      top: 0;
       width: 100%;
       height: 100%;
-      position: absolute;
-      left: 0;
+      z-index: -10;
+      background: $primary-background-color $background-image no-repeat center center;
+
       background-size: $background-size;
+      -webkit-background-size: $background-size;
+      -moz-background-size: $background-size;
+      -o-background-size: $background-size;
+
       opacity: $background-opacity;
     }
 


### PR DESCRIPTION
The PR addresses the issue on mobile where the background isn't fixed and instead scrolls with the page. tl;dr, apparently this is an expensive operation so a lot of mobile browsers disable it. The implementation here appears to work in Safari, and mostly works in Chrome and Firefox, except that the image bounces around a little when the mobile meta-ui (address bar and window buttons on bottom on iOS) changes.