### PR TITLE
Remove the volunteer interest form.

### DIFF
--- a/pug/src/staff/application.pug
+++ b/pug/src/staff/application.pug
@@ -35,8 +35,7 @@ block content
 
         h1 Volunteer Interest
 
-        p
-            | Not quite ready to make the leap to being staff? That's fine! We're looking for volunteers too.
-            | Volunteering is currently on a per-event basis. If you want to be informed when volunteer applications
-            | open for our events, fill out our #[a(href='https://forms.gle/PEhLzT8SvVrMbKZb6') volunteer interest]
-            | form and we'll be sure to keep you in the loop. (You must be registered for an event before applying as a volunteer.)
+        p.
+            Not quite ready to make the leap to being staff? That's fine! We're looking for volunteers too.
+            Volunteering is currently on a per-event basis and applications will be announced on our social media.
+            See #[a(href='/') our home page] for our primary social media accounts.


### PR DESCRIPTION
This removes a seldom-used general volunteer interest form in favor of pointing folks to our social media accounts where specific volunteering opportunities are advertised.