### PR TITLE
Remove the old CFF dates.

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -79,7 +79,7 @@
     Carolina Furfare: Medieval in the Mountains! After a close call with some nefarious networking (and some 
     well-deserved time to rest), our intrepid Possum and Squirrel duo are going old school—way back to the Bark Ages! 
     Dust off your armor, grab your best cloak, stock up on just a ridiculous amount of eye-liner, and quest for a 
-    weekend of furry fun and outraaaaageous accents at the Hickory Metro Convention Center, October 4-6!
+    weekend of furry fun and outraaaaageous accents at the Hickory Metro Convention Center!
   
     See you at the Furfare! Huzzah!
 


### PR DESCRIPTION
We accidentally left the old CFF dates in the description after it was canceled. Remove those.